### PR TITLE
(SIMP-3290) Add .pmtignore

### DIFF
--- a/.pmtignore
+++ b/.pmtignore
@@ -1,0 +1,1 @@
+/spec/acceptance/

--- a/.pmtignore
+++ b/.pmtignore
@@ -1,1 +1,2 @@
 /spec/acceptance/
+dist/


### PR DESCRIPTION
Necessary to publish the module as-is to the Forge. In the future,
this will most likely become a global static asset.