### PR TITLE
(SIMP-5977) Remove spoof options from host.conf

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,6 +3,7 @@ fixtures:
   repositories:
     named: "https://github.com/simp/pupmod-simp-named.git"
     rsync: "https://github.com/simp/pupmod-simp-rsync.git"
+    selinux_core: "https://github.com/simp/pupmod-puppetlabs-selinux_core"
     stdlib: "https://github.com/simp/puppetlabs-stdlib.git"
     simplib: "https://github.com/simp/pupmod-simp-simplib.git"
     simpcat: "https://github.com/simp/pupmod-simp-simpcat.git"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,6 @@ global:
   - STRICT_VARIABLES=yes
 
 jobs:
-  allow_failures:
-    - name: 'Latest Puppet 6.x (allowed to fail)'
-
   include:
     - stage: check
       name: 'Syntax, style, and validation checks'
@@ -90,7 +87,7 @@ jobs:
         - bundle exec rake spec
 
     - stage: spec
-      name: 'Latest Puppet 6.x (allowed to fail)'
+      name: 'Latest Puppet 6.x'
       rvm: 2.5.1
       env: PUPPET_VERSION="~> 6.0"
       script:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
   actual effect on the system. See
   https://bugzilla.redhat.com/show_bug.cgi?id=1577265 for information.
 - Add official support for Puppet 6
+- Update URLs in the README.md
 
 * Fri Sep 07 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 0.1.1-0
 - Drop Hiera 4 support

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
   https://bugzilla.redhat.com/show_bug.cgi?id=1577265 for information.
 - Add official support for Puppet 6
 - Update URLs in the README.md
+- Update upperbound of stdlib
 
 * Fri Sep 07 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 0.1.1-0
 - Drop Hiera 4 support

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Wed Mar 06 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.2-0
+- Deprecate the 'resolv::host_conf::spoof' parameter since it does not have any
+  actual effect on the system. See
+  https://bugzilla.redhat.com/show_bug.cgi?id=1577265 for information.
+- Add official support for Puppet 6
+
 * Fri Sep 07 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 0.1.1-0
 - Drop Hiera 4 support
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-[![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html) [![Build Status](https://travis-ci.org/simp/pupmod-simp-resolv.svg)](https://travis-ci.org/simp/pupmod-simp-resolv) [![SIMP compatibility](https://img.shields.io/badge/SIMP%20compatibility-6.*-orange.svg)](https://img.shields.io/badge/SIMP%20compatibility-6.*-orange.svg)
+![License](https://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/73/badge)](https://bestpractices.coreinfrastructure.org/projects/73)
+[![Puppet Forge](https://img.shields.io/puppetforge/v/simp/resolv.svg)](https://forge.puppetlabs.com/simp/resolv)
+[![Puppet Forge Downloads](https://img.shields.io/puppetforge/dt/simp/resolv.svg)](https://forge.puppetlabs.com/simp/resolv)
+[![Build Status](https://travis-ci.org/simp/pupmod-simp-resolv.svg)](https://travis-ci.org/simp/pupmod-simp-resolv)
 
 #### Table of Contents
 
@@ -21,7 +25,8 @@ This module sets up DNS client config, including `/etc/resolv.conf` and `/etc/ho
 
 ### This is a SIMP module
 
-This module is a component of the [System Integrity Management Platform](https://github.com/NationalSecurityAgency/SIMP), a compliance-management framework built on Puppet.
+This module is a component of the [System Integrity Management Platform](https://simp-project.com),
+a compliance-management framework built on Puppet.
 
 If you find any issues, they may be submitted to our [bug tracker](https://simp-project.atlassian.net/).
 
@@ -74,4 +79,4 @@ SIMP Puppet modules are generally intended for use on Red Hat Enterprise Linux a
 
 ## Development
 
-Please read our [Contribution Guide] (http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide] (https://simp.readthedocs.io/en/stable/contributors_guide/index.html).

--- a/manifests/host_conf.pp
+++ b/manifests/host_conf.pp
@@ -1,10 +1,17 @@
 # This class configures /etc/host.conf.
 # See host.conf(5) for descriptions of the variables.
 #
+# @param trim
+# @param multi
+# @param spoof
+#   defunct, see: https://bugzilla.redhat.com/show_bug.cgi?id=1577265)
+#
+#   Remains to prevent issues with direct ``class`` calls.
+# @param reorder
 class resolv::host_conf (
   Optional[Array[Pattern[/^\./]]] $trim    = undef,
   Boolean                         $multi   = true,
-  Enum['off','nowarn','warn']     $spoof   = 'warn',
+  Optional[String]                $spoof   = undef,
   Boolean                         $reorder = true
 ) {
 
@@ -13,5 +20,12 @@ class resolv::host_conf (
     group   => 'root',
     mode    => '0644',
     content => template('resolv/etc/host.conf.erb')
+  }
+
+  if $spoof {
+    simplib::deprecation(
+      'resolv::host_conf::spoof',
+      'resolv::host_conf::spoof has been deprecated since it has no effect on the system'
+    )
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-resolv",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "SIMP Team",
   "summary": "A SIMP Puppet module for managing client-side DNS settings",
   "license": "Apache-2.0",
@@ -52,7 +52,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.4 < 6.0.0"
+      "version_requirement": ">= 4.10.4 < 7.0.0"
     }
   ]
 }

--- a/spec/classes/host_conf_spec.rb
+++ b/spec/classes/host_conf_spec.rb
@@ -12,7 +12,6 @@ describe 'resolv::host_conf' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_file('/etc/host.conf').with_content(<<-EOM.gsub(/^\s+/,''))
             multi on
-            spoof warn
             reorder on
             EOM
           }
@@ -22,7 +21,6 @@ describe 'resolv::host_conf' do
           let(:params){{ :trim => ['.bar.baz','.alpha.beta'] }}
           it { is_expected.to create_file('/etc/host.conf').with_content(<<-EOM.gsub(/^\s+/,''))
              multi on
-             spoof warn
              reorder on
              trim .bar.baz,.alpha.beta
              EOM
@@ -36,6 +34,11 @@ describe 'resolv::host_conf' do
               is_expected.to compile.with_all_deps
             }.to raise_error(/expects a match for Pattern/)
           }
+        end
+
+        context 'with spoof' do
+          let(:params){{ :spoof => 'warn' }}
+          it { is_expected.to compile.with_all_deps }
         end
       end
     end

--- a/templates/etc/host.conf.erb
+++ b/templates/etc/host.conf.erb
@@ -1,6 +1,5 @@
 multi <%= @multi ? 'on' : 'off' %>
-spoof <%= @spoof %>
 reorder <%= @reorder ? 'on' : 'off' %>
-<% if ! @trim.nil? then -%>
+<% if @trim -%>
 trim <%= @trim.join(',') %>
 <% end -%>


### PR DESCRIPTION
* Deprecated the 'spoof' option in /etc/host.conf since it hasn't done
  anything in recent history:
  https://bugzilla.redhat.com/show_bug.cgi?id=1577265
* Added Puppet 6 support

SIMP-5977 #close