### PR TITLE
Add clean-state noop acceptance test

### DIFF
--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -5,30 +5,6 @@ test_name 'resolv'
 describe 'resolv' do
   let(:servers) { ['8.8.8.8', '8.8.4.4', '1.1.1.1'] }
 
-  # On a fresh node the Sicura console previews this module with
-  # `puppet apply --noop`, which must not error. Exercise that here before the
-  # prep/apply contexts below. No package-removal step: resolv manages
-  # /etc/resolv.conf + network config only, so noop-only is the representative
-  # check. `servers` is required, so we noop the same manifest as the first
-  # real context (there is no bare-default manifest to reuse).
-  hosts.each do |host|
-    context 'in noop mode from a clean state' do
-      let(:noop_manifest) do
-        <<~EOF
-          class { 'resolv':
-            servers   => #{servers.reverse},
-            search    => ['simp.beaker', 'foo.bar', 'bar.baz'],
-            use_nmcli => false,
-          }
-        EOF
-      end
-
-      it 'applies without errors in noop mode' do
-        apply_manifest_on(host, noop_manifest, catch_failures: true, noop: true)
-      end
-    end
-  end
-
   hosts.each do |host|
     context "prep #{host}" do
       # Under Docker, /etc/resolv.conf is a bind mount injected by the
@@ -62,6 +38,34 @@ describe 'resolv' do
       it 'removes the fix-slow-dns script' do
         on(host, 'puppet resource file /etc/NetworkManager/dispatcher.d/fix-slow-dns ensure=absent')
         on(host, %(sed -i '/options/d' /etc/resolv.conf), accept_all_exit_codes: true)
+      end
+    end
+  end
+
+  # On a fresh node the Sicura console previews this module with
+  # `puppet apply --noop`, which must not error. Exercise that here, after the
+  # prep normalizations above (which touch /etc/sysconfig/network and detach
+  # the resolv.conf bind mount so a minimal container mirrors a real EL node)
+  # but before any real apply below. Running before prep fails on minimal
+  # EL9/EL10 containers: the module's Simp_file_line[resolv_peerdns] reads
+  # /etc/sysconfig/network even under --noop, and that file is absent until
+  # prep touches it. No package-removal step: resolv manages
+  # /etc/resolv.conf + network config only. `servers` is required, so we noop
+  # the same manifest as the first real context.
+  hosts.each do |host|
+    context 'in noop mode from a clean state' do
+      let(:noop_manifest) do
+        <<~EOF
+          class { 'resolv':
+            servers   => #{servers.reverse},
+            search    => ['simp.beaker', 'foo.bar', 'bar.baz'],
+            use_nmcli => false,
+          }
+        EOF
+      end
+
+      it 'applies without errors in noop mode' do
+        apply_manifest_on(host, noop_manifest, catch_failures: true, noop: true)
       end
     end
   end

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -5,6 +5,30 @@ test_name 'resolv'
 describe 'resolv' do
   let(:servers) { ['8.8.8.8', '8.8.4.4', '1.1.1.1'] }
 
+  # On a fresh node the Sicura console previews this module with
+  # `puppet apply --noop`, which must not error. Exercise that here before the
+  # prep/apply contexts below. No package-removal step: resolv manages
+  # /etc/resolv.conf + network config only, so noop-only is the representative
+  # check. `servers` is required, so we noop the same manifest as the first
+  # real context (there is no bare-default manifest to reuse).
+  hosts.each do |host|
+    context 'in noop mode from a clean state' do
+      let(:noop_manifest) do
+        <<~EOF
+          class { 'resolv':
+            servers   => #{servers.reverse},
+            search    => ['simp.beaker', 'foo.bar', 'bar.baz'],
+            use_nmcli => false,
+          }
+        EOF
+      end
+
+      it 'applies without errors in noop mode' do
+        apply_manifest_on(host, noop_manifest, catch_failures: true, noop: true)
+      end
+    end
+  end
+
   hosts.each do |host|
     context "prep #{host}" do
       # Under Docker, /etc/resolv.conf is a bind mount injected by the


### PR DESCRIPTION
On a fresh node the Sicura console previews this module with `puppet apply --noop`, which must not error. This adds a noop-from-clean-state example that applies the module manifest with `noop: true` before the existing applies. No package-removal step — resolv manages config/state only, so noop-only is the representative check (matching the merged fips PR).

Note: `servers` is required, so the noop applies the same manifest as the first real context (there is no bare-default manifest to reuse).